### PR TITLE
init for Fragment wasn't public

### DIFF
--- a/GraphQL/GraphQL.swift
+++ b/GraphQL/GraphQL.swift
@@ -185,7 +185,7 @@ public struct GraphQL {
         public let typeCondition: String
         public let selectionSet: SelectionSet
         
-        init(name: String, typeCondition: String, selectionSet: SelectionSet) {
+        public init(name: String, typeCondition: String, selectionSet: SelectionSet) {
             self.name = name
             self.typeCondition = typeCondition
             self.selectionSet = selectionSet


### PR DESCRIPTION
It fixes the compiling error due to the fact that init for Fragment wasn't exposed
